### PR TITLE
feat: Add thousand separators to monetary fields

### DIFF
--- a/composables/useUtils.ts
+++ b/composables/useUtils.ts
@@ -1,0 +1,21 @@
+export const useUtils = () => {
+  const formatNumber = (value: number | string | null | undefined): string => {
+    if (value === null || value === undefined) {
+      return '';
+    }
+    const num = typeof value === 'string' ? parseFloat(value.replace(/,/g, '')) : value;
+    if (isNaN(num)) {
+      return '';
+    }
+    return num.toLocaleString('en-US');
+  };
+
+  const parseNumber = (value: string): number => {
+    return Number(value.replace(/,/g, ''));
+  };
+
+  return {
+    formatNumber,
+    parseNumber,
+  };
+};


### PR DESCRIPTION
- Creates a `useUtils` composable with `formatNumber` and `parseNumber` helpers to handle number formatting.
- Refactors the monetary input fields in `pages/dashboard.vue` (`signupFirstPurchaseAmount` and `purchaseAmount`) to use a `computed` property with a custom getter/setter for robust, real-time formatting.
- Changes input types from `number` to `text` to allow for commas and adds `inputmode="numeric"` for better mobile UX.
- Applies `formatNumber` to all displayed monetary values (`totalDiscount`, `finalPrice`) for consistent UI presentation.